### PR TITLE
VectorMaskCast implementation on x86

### DIFF
--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -4565,6 +4565,138 @@ void C2_MacroAssembler::vector_unsigned_cast(XMMRegister dst, XMMRegister src, i
   }
 }
 
+void C2_MacroAssembler::vector_mask_cast(XMMRegister dst, XMMRegister src,
+                                         BasicType dst_bt, BasicType src_bt, int vlen) {
+  int vlen_enc = vector_length_encoding(MAX2(type2aelembytes(src_bt), type2aelembytes(dst_bt)) * vlen);
+  int dst_bt_size = type2aelembytes(dst_bt);
+  int src_bt_size = type2aelembytes(src_bt);
+  if (dst_bt_size > src_bt_size) {
+    switch (dst_bt_size / src_bt_size) {
+      case 2: {
+        if (vlen_enc == AVX_512bit && !VM_Version::supports_avx512bw()) {
+          vpmovsxdq(dst, src, vlen_enc);
+        } else {
+          vpmovsxbw(dst, src, vlen_enc);
+        }
+        break;
+      }
+      case 4: vpmovsxbd(dst, src, vlen_enc); break;
+      case 8: vpmovsxbq(dst, src, vlen_enc); break;
+      default: ShouldNotReachHere();
+    }
+  } else {
+    assert(dst_bt_size < src_bt_size, "");
+    switch (src_bt_size / dst_bt_size) {
+      case 2: {
+        if (vlen_enc == AVX_512bit) {
+          if (VM_Version::supports_avx512bw()) {
+            evpmovwb(dst, src, vlen_enc);
+          } else {
+            evpmovqd(dst, src, vlen_enc);
+          }
+        } else if (VM_Version::supports_avx512vl()) {
+          if (VM_Version::supports_avx512bw()) {
+            evpmovwb(dst, src, vlen_enc);
+          } else if (dst_bt != T_BYTE) {
+            evpmovdw(dst, src, vlen_enc);
+          } else if (vlen_enc == AVX_128bit) {
+            vpacksswb(dst, src, src, vlen_enc);
+          } else {
+            vpacksswb(dst, src, src, vlen_enc);
+            vpermq(dst, dst, 0x08, vlen_enc);
+          }
+        } else {
+          if (vlen_enc == AVX_128bit) {
+            vpacksswb(dst, src, src, vlen_enc);
+          } else {
+            vpacksswb(dst, src, src, vlen_enc);
+            vpermq(dst, dst, 0x08, vlen_enc);
+          }
+        }
+        break;
+      }
+      case 4: {
+        if (vlen_enc == AVX_512bit || VM_Version::supports_avx512vl()) {
+          evpmovdb(dst, src, vlen_enc);
+        } else if (vlen_enc == AVX_128bit) {
+          vpackssdw(dst, src, src, vlen_enc);
+          vpacksswb(dst, dst, dst, vlen_enc);
+        } else {
+          vpackssdw(dst, src, src, vlen_enc);
+          vpermq(dst, dst, 0x08, vlen_enc);
+          vpacksswb(dst, dst, dst, AVX_128bit);
+        }
+        break;
+      }
+      case 8: {
+        if (vlen_enc == AVX_512bit || VM_Version::supports_avx512vl()) {
+          evpmovqb(dst, src, vlen_enc);
+        } else if (vlen_enc == AVX_128bit) {
+          vpshufd(dst, src, 0x08, vlen_enc);
+          vpackssdw(dst, dst, dst, vlen_enc);
+          vpacksswb(dst, dst, dst, vlen_enc);
+        } else {
+          vpshufd(dst, src, 0x08, vlen_enc);
+          vpermq(dst, dst, 0x08, vlen_enc);
+          vpackssdw(dst, dst, dst, AVX_128bit);
+          vpacksswb(dst, dst, dst, AVX_128bit);
+        }
+        break;
+      }
+      default: ShouldNotReachHere();
+    }
+  }
+}
+
+void C2_MacroAssembler::vector_mask_cast_with_tmp(XMMRegister dst, XMMRegister src, XMMRegister xtmp,
+                                                  BasicType dst_bt, BasicType src_bt, int vlen) {
+  int dst_bt_size = type2aelembytes(dst_bt);
+  int src_bt_size = type2aelembytes(src_bt);
+  if (dst_bt_size > src_bt_size) {
+    switch (dst_bt_size / src_bt_size) {
+      case 2:
+        vpmovsxbw(xtmp, src, AVX_128bit);
+        vpshufd(dst, src, 0x0E, AVX_128bit);
+        vpmovsxbw(dst, dst, AVX_128bit);
+        vinsertf128(dst, xtmp, dst, 0x01);
+        break;
+      case 4:
+        vpmovsxbd(xtmp, src, AVX_128bit);
+        vpshufd(dst, src, 0x01, AVX_128bit);
+        vpmovsxbd(dst, dst, AVX_128bit);
+        vinsertf128(dst, xtmp, dst, 0x01);
+        break;
+      case 8:
+        vpmovsxbq(xtmp, src, AVX_128bit);
+        pshuflw(dst, src, 0x01);
+        vpmovsxbq(dst, dst, AVX_128bit);
+        vinsertf128(dst, xtmp, dst, 0x01);
+        break;
+      default: ShouldNotReachHere();
+    }
+  } else {
+    assert(dst_bt_size < src_bt_size, "");
+    switch (src_bt_size / dst_bt_size) {
+      case 2:
+        vextractf128(xtmp, src, 0x01);
+        vpacksswb(dst, src, xtmp, AVX_128bit);
+        break;
+      case 4:
+        vextractf128(xtmp, src, 0x01);
+        vpackssdw(dst, src, xtmp, AVX_128bit);
+        vpacksswb(dst, dst, dst, AVX_128bit);
+        break;
+      case 8:
+        vpermilps(dst, src, 0x08, AVX_256bit);
+        vpermpd(dst, dst, 0x08, AVX_256bit);
+        vpackssdw(dst, dst, dst, AVX_128bit);
+        vpackssdw(dst, dst, dst, AVX_128bit);
+        break;
+      default: ShouldNotReachHere();
+    }
+  }
+}
+
 void C2_MacroAssembler::evpternlog(XMMRegister dst, int func, KRegister mask, XMMRegister src2, XMMRegister src3,
                                    bool merge, BasicType bt, int vlen_enc) {
   if (bt == T_INT) {

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -4691,7 +4691,7 @@ void C2_MacroAssembler::vector_mask_cast_with_tmp(XMMRegister dst, XMMRegister s
         vpermilps(dst, src, 0x08, AVX_256bit);
         vpermpd(dst, dst, 0x08, AVX_256bit);
         vpackssdw(dst, dst, dst, AVX_128bit);
-        vpackssdw(dst, dst, dst, AVX_128bit);
+        vpacksswb(dst, dst, dst, AVX_128bit);
         break;
       default: ShouldNotReachHere();
     }

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -4648,42 +4648,43 @@ void C2_MacroAssembler::vector_mask_cast(XMMRegister dst, XMMRegister src,
   }
 }
 
-void C2_MacroAssembler::vector_mask_cast_with_tmp(XMMRegister dst, XMMRegister src, XMMRegister xtmp,
+void C2_MacroAssembler::vector_mask_cast_with_tmp(XMMRegister dst, XMMRegister src, XMMRegister xtmp1, XMMRegister xtmp2,
                                                   BasicType dst_bt, BasicType src_bt, int vlen) {
   int dst_bt_size = type2aelembytes(dst_bt);
   int src_bt_size = type2aelembytes(src_bt);
   if (dst_bt_size > src_bt_size) {
     switch (dst_bt_size / src_bt_size) {
       case 2:
-        vpmovsxbw(xtmp, src, AVX_128bit);
-        vpshufd(dst, src, 0x0E, AVX_128bit);
-        vpmovsxbw(dst, dst, AVX_128bit);
-        vinsertf128(dst, xtmp, dst, 0x01);
+        vpmovsxbw(xtmp1, src, AVX_128bit);
+        vpshufd(xtmp2, src, 0x0E, AVX_128bit);
+        vpmovsxbw(xtmp2, xtmp2, AVX_128bit);
+        vinsertf128(dst, xtmp1, xtmp2, 0x01);
         break;
       case 4:
-        vpmovsxbd(xtmp, src, AVX_128bit);
-        vpshufd(dst, src, 0x01, AVX_128bit);
-        vpmovsxbd(dst, dst, AVX_128bit);
-        vinsertf128(dst, xtmp, dst, 0x01);
+        vpmovsxbd(xtmp1, src, AVX_128bit);
+        vpshufd(xtmp2, src, 0x01, AVX_128bit);
+        vpmovsxbd(xtmp2, xtmp2, AVX_128bit);
+        vinsertf128(dst, xtmp1, xtmp2, 0x01);
         break;
       case 8:
-        vpmovsxbq(xtmp, src, AVX_128bit);
-        pshuflw(dst, src, 0x01);
-        vpmovsxbq(dst, dst, AVX_128bit);
-        vinsertf128(dst, xtmp, dst, 0x01);
+        vpmovsxbq(xtmp1, src, AVX_128bit);
+        pshuflw(xtmp2, src, 0x01);
+        vpmovsxbq(xtmp2, xtmp2, AVX_128bit);
+        vinsertf128(dst, xtmp1, xtmp2, 0x01);
         break;
       default: ShouldNotReachHere();
     }
   } else {
     assert(dst_bt_size < src_bt_size, "");
+    assert(xtmp2 == xnoreg, "");
     switch (src_bt_size / dst_bt_size) {
       case 2:
-        vextractf128(xtmp, src, 0x01);
-        vpacksswb(dst, src, xtmp, AVX_128bit);
+        vextractf128(xtmp1, src, 0x01);
+        vpacksswb(dst, src, xtmp1, AVX_128bit);
         break;
       case 4:
-        vextractf128(xtmp, src, 0x01);
-        vpackssdw(dst, src, xtmp, AVX_128bit);
+        vextractf128(xtmp1, src, 0x01);
+        vpackssdw(dst, src, xtmp1, AVX_128bit);
         vpacksswb(dst, dst, dst, AVX_128bit);
         break;
       case 8:

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -4648,8 +4648,8 @@ void C2_MacroAssembler::vector_mask_cast(XMMRegister dst, XMMRegister src,
   }
 }
 
-void C2_MacroAssembler::vector_mask_cast_with_tmp(XMMRegister dst, XMMRegister src, XMMRegister xtmp1, XMMRegister xtmp2,
-                                                  BasicType dst_bt, BasicType src_bt, int vlen) {
+void C2_MacroAssembler::vector_mask_cast_with_tmp(XMMRegister dst, XMMRegister src, XMMRegister xtmp1,
+                                                  XMMRegister xtmp2, BasicType dst_bt, BasicType src_bt, int vlen) {
   int dst_bt_size = type2aelembytes(dst_bt);
   int src_bt_size = type2aelembytes(src_bt);
   if (dst_bt_size > src_bt_size) {

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.hpp
@@ -332,8 +332,8 @@ public:
                             BasicType from_elem_bt, BasicType to_elem_bt);
 
   void vector_mask_cast(XMMRegister dst, XMMRegister src, BasicType dst_bt, BasicType src_bt, int vlen);
-  void vector_mask_cast_with_tmp(XMMRegister dst, XMMRegister src, XMMRegister xtmp,
-                                 BasicType dst_bt, BasicType src_bt, int vlen);
+  void vector_mask_cast_with_tmp(XMMRegister dst, XMMRegister src, XMMRegister xtmp1,
+                                 XMMRegister xtmp2, BasicType dst_bt, BasicType src_bt, int vlen);
 
   void vector_cast_double_special_cases_evex(XMMRegister dst, XMMRegister src, XMMRegister xtmp1, XMMRegister xtmp2,
                                              KRegister ktmp1, KRegister ktmp2, Register scratch, AddressLiteral double_sign_flip,

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.hpp
@@ -331,6 +331,10 @@ public:
   void vector_unsigned_cast(XMMRegister dst, XMMRegister src, int vlen_enc,
                             BasicType from_elem_bt, BasicType to_elem_bt);
 
+  void vector_mask_cast(XMMRegister dst, XMMRegister src, BasicType dst_bt, BasicType src_bt, int vlen);
+  void vector_mask_cast_with_tmp(XMMRegister dst, XMMRegister src, XMMRegister xtmp,
+                                 BasicType dst_bt, BasicType src_bt, int vlen);
+
   void vector_cast_double_special_cases_evex(XMMRegister dst, XMMRegister src, XMMRegister xtmp1, XMMRegister xtmp2,
                                              KRegister ktmp1, KRegister ktmp2, Register scratch, AddressLiteral double_sign_flip,
                                              int vec_enc);

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -1480,6 +1480,7 @@ const bool Matcher::match_rule_supported(int opcode) {
     case Op_VectorUCastB2X:
     case Op_VectorUCastS2X:
     case Op_VectorUCastI2X:
+    case Op_VectorMaskCast:
       if (UseAVX < 1) { // enabled for AVX only
         return false;
       }

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -8428,6 +8428,41 @@ instruct vmaskcast(vec dst) %{
   ins_pipe(empty);
 %}
 
+instruct vmaskcast_avx(vec dst, vec src) %{
+  predicate(Matcher::vector_length(n) == Matcher::vector_length(n->in(1)) &&
+            Matcher::vector_length_in_bytes(n) != Matcher::vector_length_in_bytes(n->in(1)) &&
+            (UseAVX >= 2 ||
+             (Matcher::vector_length_in_bytes(n) != 32 &&
+              Matcher::vector_length_in_bytes(n->in(1)) != 32)));
+  match(Set dst (VectorMaskCast src));
+  format %{ "vector_mask_cast $dst, $src" %}
+  ins_encode %{
+    int vlen = Matcher::vector_length(this);
+    BasicType src_bt = Matcher::vector_element_basic_type(this, $src);
+    BasicType dst_bt = Matcher::vector_element_basic_type(this);
+    __ vector_mask_cast($dst$$XMMRegister, $src$$XMMRegister, dst_bt, src_bt, vlen);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vmaskcast_avx1_32B(vec dst, vec src, vec xtmp) %{
+  predicate(Matcher::vector_length(n) == Matcher::vector_length(n->in(1)) &&
+            Matcher::vector_length_in_bytes(n) != Matcher::vector_length_in_bytes(n->in(1)) &&
+            UseAVX == 1 &&
+            (Matcher::vector_length_in_bytes(n) == 32 ||
+             Matcher::vector_length_in_bytes(n->in(1)) == 32));
+  match(Set dst (VectorMaskCast src));
+  effect(TEMP dst, TEMP xtmp);
+  format %{ "vector_mask_cast $dst, $src\t! using $xtmp as TEMP" %}
+  ins_encode %{
+    int vlen = Matcher::vector_length(this);
+    BasicType src_bt = Matcher::vector_element_basic_type(this, $src);
+    BasicType dst_bt = Matcher::vector_element_basic_type(this);
+    __ vector_mask_cast_with_tmp($dst$$XMMRegister, $src$$XMMRegister, $xtmp$$XMMRegister, dst_bt, src_bt, vlen);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
 //-------------------------------- Load Iota Indices ----------------------------------
 
 instruct loadIotaIndices(vec dst, immI_0 src, rRegP scratch) %{

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -8445,20 +8445,38 @@ instruct vmaskcast_avx(vec dst, vec src) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vmaskcast_avx1_32B(vec dst, vec src, vec xtmp) %{
+instruct vmaskcast_avx1_32B_expand(vec dst, vec src, vec xtmp1, vec xtmp2) %{
   predicate(Matcher::vector_length(n) == Matcher::vector_length(n->in(1)) &&
-            Matcher::vector_length_in_bytes(n) != Matcher::vector_length_in_bytes(n->in(1)) &&
+            Matcher::vector_length_in_bytes(n) > Matcher::vector_length_in_bytes(n->in(1)) &&
             UseAVX == 1 &&
-            (Matcher::vector_length_in_bytes(n) == 32 ||
-             Matcher::vector_length_in_bytes(n->in(1)) == 32));
+            Matcher::vector_length_in_bytes(n) == 32);
   match(Set dst (VectorMaskCast src));
-  effect(TEMP dst, TEMP xtmp);
+  effect(TEMP xtmp1, TEMP xtmp2);
+  format %{ "vector_mask_cast $dst, $src\t! using $xtmp1, $xtmp2 as TEMP" %}
+  ins_encode %{
+    int vlen = Matcher::vector_length(this);
+    BasicType src_bt = Matcher::vector_element_basic_type(this, $src);
+    BasicType dst_bt = Matcher::vector_element_basic_type(this);
+    __ vector_mask_cast_with_tmp($dst$$XMMRegister, $src$$XMMRegister, $xtmp1$$XMMRegister,
+                                 $xtmp2$$XMMRegister, dst_bt, src_bt, vlen);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vmaskcast_avx1_32B_shrink(vec dst, vec src, vec xtmp) %{
+  predicate(Matcher::vector_length(n) == Matcher::vector_length(n->in(1)) &&
+            Matcher::vector_length_in_bytes(n) < Matcher::vector_length_in_bytes(n->in(1)) &&
+            UseAVX == 1 &&
+            Matcher::vector_length_in_bytes(n->in(1)) == 32);
+  match(Set dst (VectorMaskCast src));
+  effect(TEMP xtmp);
   format %{ "vector_mask_cast $dst, $src\t! using $xtmp as TEMP" %}
   ins_encode %{
     int vlen = Matcher::vector_length(this);
     BasicType src_bt = Matcher::vector_element_basic_type(this, $src);
     BasicType dst_bt = Matcher::vector_element_basic_type(this);
-    __ vector_mask_cast_with_tmp($dst$$XMMRegister, $src$$XMMRegister, $xtmp$$XMMRegister, dst_bt, src_bt, vlen);
+    __ vector_mask_cast_with_tmp($dst$$XMMRegister, $src$$XMMRegister, $xtmp$$XMMRegister,
+                                 xnoreg, dst_bt, src_bt, vlen);
   %}
   ins_pipe(pipe_slow);
 %}


### PR DESCRIPTION
This is the implementation of VectorMaskCast to perform conversion on non-predicated mask vector on x86.  I actually have not tested the code in details since the mid-end part is not there yet.

Thanks a lot.