### PR TITLE
Remove untaken code paths

### DIFF
--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -4622,14 +4622,7 @@ void C2_MacroAssembler::vector_mask_cast(XMMRegister dst, XMMRegister src,
   int src_bt_size = type2aelembytes(src_bt);
   if (dst_bt_size > src_bt_size) {
     switch (dst_bt_size / src_bt_size) {
-      case 2: {
-        if (vlen_enc == AVX_512bit && !VM_Version::supports_avx512bw()) {
-          vpmovsxwd(dst, src, vlen_enc);
-        } else {
-          vpmovsxbw(dst, src, vlen_enc);
-        }
-        break;
-      }
+      case 2: vpmovsxbw(dst, src, vlen_enc); break;
       case 4: vpmovsxbd(dst, src, vlen_enc); break;
       case 8: vpmovsxbq(dst, src, vlen_enc); break;
       default: ShouldNotReachHere();
@@ -4638,37 +4631,16 @@ void C2_MacroAssembler::vector_mask_cast(XMMRegister dst, XMMRegister src,
     assert(dst_bt_size < src_bt_size, "");
     switch (src_bt_size / dst_bt_size) {
       case 2: {
-        if (vlen_enc == AVX_512bit) {
-          if (VM_Version::supports_avx512bw()) {
-            evpmovwb(dst, src, vlen_enc);
-          } else {
-            evpmovdw(dst, src, vlen_enc);
-          }
-        } else if (VM_Version::supports_avx512vl()) {
-          if (VM_Version::supports_avx512bw()) {
-            evpmovwb(dst, src, vlen_enc);
-          } else if (dst_bt != T_BYTE) {
-            evpmovdw(dst, src, vlen_enc);
-          } else if (vlen_enc == AVX_128bit) {
-            vpacksswb(dst, src, src, vlen_enc);
-          } else {
-            vpacksswb(dst, src, src, vlen_enc);
-            vpermq(dst, dst, 0x08, vlen_enc);
-          }
+        if (vlen_enc == AVX_128bit) {
+          vpacksswb(dst, src, src, vlen_enc);
         } else {
-          if (vlen_enc == AVX_128bit) {
-            vpacksswb(dst, src, src, vlen_enc);
-          } else {
-            vpacksswb(dst, src, src, vlen_enc);
-            vpermq(dst, dst, 0x08, vlen_enc);
-          }
+          vpacksswb(dst, src, src, vlen_enc);
+          vpermq(dst, dst, 0x08, vlen_enc);
         }
         break;
       }
       case 4: {
-        if (vlen_enc == AVX_512bit || VM_Version::supports_avx512vl()) {
-          evpmovdb(dst, src, vlen_enc);
-        } else if (vlen_enc == AVX_128bit) {
+        if (vlen_enc == AVX_128bit) {
           vpackssdw(dst, src, src, vlen_enc);
           vpacksswb(dst, dst, dst, vlen_enc);
         } else {
@@ -4679,9 +4651,7 @@ void C2_MacroAssembler::vector_mask_cast(XMMRegister dst, XMMRegister src,
         break;
       }
       case 8: {
-        if (vlen_enc == AVX_512bit || VM_Version::supports_avx512vl()) {
-          evpmovqb(dst, src, vlen_enc);
-        } else if (vlen_enc == AVX_128bit) {
+        if (vlen_enc == AVX_128bit) {
           vpshufd(dst, src, 0x08, vlen_enc);
           vpackssdw(dst, dst, dst, vlen_enc);
           vpacksswb(dst, dst, dst, vlen_enc);
@@ -4693,56 +4663,6 @@ void C2_MacroAssembler::vector_mask_cast(XMMRegister dst, XMMRegister src,
         }
         break;
       }
-      default: ShouldNotReachHere();
-    }
-  }
-}
-
-void C2_MacroAssembler::vector_mask_cast(XMMRegister dst, XMMRegister src, XMMRegister xtmp1,
-                                         XMMRegister xtmp2, BasicType dst_bt, BasicType src_bt, int vlen) {
-  int dst_bt_size = type2aelembytes(dst_bt);
-  int src_bt_size = type2aelembytes(src_bt);
-  if (dst_bt_size > src_bt_size) {
-    switch (dst_bt_size / src_bt_size) {
-      case 2:
-        vpmovsxbw(xtmp1, src, AVX_128bit);
-        vpshufd(xtmp2, src, 0x0E, AVX_128bit);
-        vpmovsxbw(xtmp2, xtmp2, AVX_128bit);
-        vinsertf128(dst, xtmp1, xtmp2, 0x01);
-        break;
-      case 4:
-        vpmovsxbd(xtmp1, src, AVX_128bit);
-        vpshufd(xtmp2, src, 0x01, AVX_128bit);
-        vpmovsxbd(xtmp2, xtmp2, AVX_128bit);
-        vinsertf128(dst, xtmp1, xtmp2, 0x01);
-        break;
-      case 8:
-        vpmovsxbq(xtmp1, src, AVX_128bit);
-        pshuflw(xtmp2, src, 0x01);
-        vpmovsxbq(xtmp2, xtmp2, AVX_128bit);
-        vinsertf128(dst, xtmp1, xtmp2, 0x01);
-        break;
-      default: ShouldNotReachHere();
-    }
-  } else {
-    assert(dst_bt_size < src_bt_size, "");
-    assert(xtmp2 == xnoreg, "");
-    switch (src_bt_size / dst_bt_size) {
-      case 2:
-        vextractf128(xtmp1, src, 0x01);
-        vpacksswb(dst, src, xtmp1, AVX_128bit);
-        break;
-      case 4:
-        vextractf128(xtmp1, src, 0x01);
-        vpackssdw(dst, src, xtmp1, AVX_128bit);
-        vpacksswb(dst, dst, dst, AVX_128bit);
-        break;
-      case 8:
-        vpermilps(dst, src, 0x08, AVX_256bit);
-        vpermpd(dst, dst, 0x08, AVX_256bit);
-        vpackssdw(dst, dst, dst, AVX_128bit);
-        vpacksswb(dst, dst, dst, AVX_128bit);
-        break;
       default: ShouldNotReachHere();
     }
   }

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.hpp
@@ -341,9 +341,6 @@ public:
 
   void vector_mask_cast(XMMRegister dst, XMMRegister src, BasicType dst_bt, BasicType src_bt, int vlen);
 
-  void vector_mask_cast(XMMRegister dst, XMMRegister src, XMMRegister xtmp1,
-                        XMMRegister xtmp2, BasicType dst_bt, BasicType src_bt, int vlen);
-
 #ifdef _LP64
   void vector_round_double_evex(XMMRegister dst, XMMRegister src, AddressLiteral double_sign_flip, AddressLiteral new_mxcsr, int vec_enc,
                                 Register tmp, XMMRegister xtmp1, XMMRegister xtmp2, KRegister ktmp1, KRegister ktmp2);

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -1850,6 +1850,7 @@ const bool Matcher::match_rule_supported_vector(int opcode, int vlen, BasicType 
       }
       break;
     case Op_VectorLoadMask:
+    case Op_VectorMaskCast:
       if (size_in_bits == 256 && UseAVX < 2) {
         return false; // Implementation limitation
       }
@@ -8386,7 +8387,6 @@ instruct vstoreMask_evex(vec dst, kReg mask, immI size) %{
 %}
 
 instruct vmaskcast_evex(kReg dst) %{
-  predicate(Matcher::vector_length(n) == Matcher::vector_length(n->in(1)));
   match(Set dst (VectorMaskCast dst));
   ins_cost(0);
   format %{ "vector_mask_cast $dst" %}
@@ -8397,8 +8397,7 @@ instruct vmaskcast_evex(kReg dst) %{
 %}
 
 instruct vmaskcast(vec dst) %{
-  predicate((Matcher::vector_length(n) == Matcher::vector_length(n->in(1))) &&
-            (Matcher::vector_length_in_bytes(n) == Matcher::vector_length_in_bytes(n->in(1))));
+  predicate(Matcher::vector_length_in_bytes(n) == Matcher::vector_length_in_bytes(n->in(1)));
   match(Set dst (VectorMaskCast dst));
   ins_cost(0);
   format %{ "vector_mask_cast $dst" %}
@@ -8409,11 +8408,7 @@ instruct vmaskcast(vec dst) %{
 %}
 
 instruct vmaskcast_avx(vec dst, vec src) %{
-  predicate(Matcher::vector_length(n) == Matcher::vector_length(n->in(1)) &&
-            Matcher::vector_length_in_bytes(n) != Matcher::vector_length_in_bytes(n->in(1)) &&
-            (UseAVX >= 2 ||
-             (Matcher::vector_length_in_bytes(n) != 32 &&
-              Matcher::vector_length_in_bytes(n->in(1)) != 32)));
+  predicate(Matcher::vector_length_in_bytes(n) != Matcher::vector_length_in_bytes(n->in(1)));
   match(Set dst (VectorMaskCast src));
   format %{ "vector_mask_cast $dst, $src" %}
   ins_encode %{
@@ -8421,40 +8416,6 @@ instruct vmaskcast_avx(vec dst, vec src) %{
     BasicType src_bt = Matcher::vector_element_basic_type(this, $src);
     BasicType dst_bt = Matcher::vector_element_basic_type(this);
     __ vector_mask_cast($dst$$XMMRegister, $src$$XMMRegister, dst_bt, src_bt, vlen);
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct vmaskcast_avx1_32B_expand(vec dst, vec src, vec xtmp1, vec xtmp2) %{
-  predicate(UseAVX == 1 && Matcher::vector_length_in_bytes(n) == 32 &&
-            Matcher::vector_length(n) == Matcher::vector_length(n->in(1)) &&
-            Matcher::vector_length_in_bytes(n) > Matcher::vector_length_in_bytes(n->in(1)));
-  match(Set dst (VectorMaskCast src));
-  effect(TEMP xtmp1, TEMP xtmp2);
-  format %{ "vector_mask_cast $dst, $src\t! using $xtmp1, $xtmp2 as TEMP" %}
-  ins_encode %{
-    int vlen = Matcher::vector_length(this);
-    BasicType src_bt = Matcher::vector_element_basic_type(this, $src);
-    BasicType dst_bt = Matcher::vector_element_basic_type(this);
-    __ vector_mask_cast($dst$$XMMRegister, $src$$XMMRegister, $xtmp1$$XMMRegister,
-                                 $xtmp2$$XMMRegister, dst_bt, src_bt, vlen);
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct vmaskcast_avx1_32B_shrink(vec dst, vec src, vec xtmp) %{
-  predicate(UseAVX == 1 && Matcher::vector_length_in_bytes(n->in(1)) == 32 &&
-            Matcher::vector_length(n) == Matcher::vector_length(n->in(1)) &&
-            Matcher::vector_length_in_bytes(n) < Matcher::vector_length_in_bytes(n->in(1)));
-  match(Set dst (VectorMaskCast src));
-  effect(TEMP xtmp);
-  format %{ "vector_mask_cast $dst, $src\t! using $xtmp as TEMP" %}
-  ins_encode %{
-    int vlen = Matcher::vector_length(this);
-    BasicType src_bt = Matcher::vector_element_basic_type(this, $src);
-    BasicType dst_bt = Matcher::vector_element_basic_type(this);
-    __ vector_mask_cast($dst$$XMMRegister, $src$$XMMRegister, $xtmp$$XMMRegister,
-                                 xnoreg, dst_bt, src_bt, vlen);
   %}
   ins_pipe(pipe_slow);
 %}


### PR DESCRIPTION
As reviewed by Jatin, a vector mask cannot be matched into a vector register if its length is 512 bits. Also, AVX1 cannot intrinsify 256-bit vector mask. This patch removes those untaken code paths.

Thanks a lot.